### PR TITLE
Solve the bad character in the dex file name

### DIFF
--- a/engine/jni/boot.cc
+++ b/engine/jni/boot.cc
@@ -219,6 +219,7 @@ bool Bootstrap::LoadAnalysisModule()
         idx_end = g_module_path + strlen(g_module_path) - 1;
     char keyword[kBlahSizeTiny];
     strncpy(keyword, idx_bgn, idx_end - idx_bgn + 1);
+    keyword[idx_end - idx_bgn + 1] = 0x00;
 
     char sig[kBlahSizeMid];
     snprintf(sig, kBlahSizeMid, "%s/%s.dex", dex_path_.get(), keyword);

--- a/engine/jni/boot.cc
+++ b/engine/jni/boot.cc
@@ -219,7 +219,7 @@ bool Bootstrap::LoadAnalysisModule()
         idx_end = g_module_path + strlen(g_module_path) - 1;
     char keyword[kBlahSizeTiny];
     strncpy(keyword, idx_bgn, idx_end - idx_bgn + 1);
-    keyword[idx_end - idx_bgn + 1] = 0x00;
+    keyword[idx_end - idx_bgn + 1] = 0;
 
     char sig[kBlahSizeMid];
     snprintf(sig, kBlahSizeMid, "%s/%s.dex", dex_path_.get(), keyword);


### PR DESCRIPTION
This merge request is aim to fix the issue #3 
strncpy() not put the 0 after the string keyword, put it by ourself.
